### PR TITLE
Add verse audio controls

### DIFF
--- a/wp-equran/assets/script.js
+++ b/wp-equran/assets/script.js
@@ -22,10 +22,34 @@
         cont.innerHTML='';
         data.data.ayat.forEach(function(a){
           const p = document.createElement('p');
-          p.innerHTML =
-            '<strong>'+a.nomorAyat+'</strong> '+
-            a.teksArab +
+
+          const btn = document.createElement('button');
+          btn.className = 'wp-equran-audio-btn';
+          btn.innerHTML = '<img src="'+wpEquran.pluginUrl+'/icon/play.svg" alt="play">';
+
+          const audio = document.createElement('audio');
+          const first = a.audio ? Object.values(a.audio)[0] : '';
+          if(first) audio.src = first;
+
+          btn.addEventListener('click',function(){
+            if(audio.paused){
+              audio.play();
+              btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/pause.svg';
+            } else {
+              audio.pause();
+              btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/play.svg';
+            }
+          });
+          audio.addEventListener('ended',function(){
+            btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/play.svg';
+          });
+
+          p.appendChild(btn);
+          const span = document.createElement('span');
+          span.innerHTML = '<strong>'+a.nomorAyat+'</strong> '+a.teksArab+
             '<br><em>'+a.teksLatin+'</em><br>'+a.teksIndonesia;
+          p.appendChild(span);
+          p.appendChild(audio);
           cont.appendChild(p);
         });
       });

--- a/wp-equran/assets/style.css
+++ b/wp-equran/assets/style.css
@@ -6,3 +6,18 @@
   font-family: 'LPMQ-IsepMisbah';
   src: url('../font/LPMQ-IsepMisbah.ttf') format('truetype');
 }
+
+.wp-equran-audio-btn {
+  background:none;
+  border:none;
+  cursor:pointer;
+  vertical-align:middle;
+  width:32px;
+  height:32px;
+  margin-right:6px;
+}
+.wp-equran-audio-btn img {
+  width:100%;
+  height:100%;
+  display:block;
+}


### PR DESCRIPTION
## Summary
- load audio from verse `audio` property
- add play/pause button using SVG icons
- style audio controls

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864268510348328b8795b42749e1b03