### PR TITLE
Add localization support

### DIFF
--- a/wp-equran/assets/script.js
+++ b/wp-equran/assets/script.js
@@ -25,7 +25,7 @@
 
           const btn = document.createElement('button');
           btn.className = 'wp-equran-audio-btn';
-          btn.innerHTML = '<img src="'+wpEquran.pluginUrl+'/icon/play.svg" alt="play">';
+          btn.innerHTML = '<img src="'+wpEquran.pluginUrl+'/icon/play.svg" alt="'+wpEquran.play+'">';
 
           const audio = document.createElement('audio');
           const first = a.audio ? Object.values(a.audio)[0] : '';
@@ -35,13 +35,16 @@
             if(audio.paused){
               audio.play();
               btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/pause.svg';
+              btn.querySelector('img').alt = wpEquran.pause;
             } else {
               audio.pause();
               btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/play.svg';
+              btn.querySelector('img').alt = wpEquran.play;
             }
           });
           audio.addEventListener('ended',function(){
             btn.querySelector('img').src = wpEquran.pluginUrl+'/icon/play.svg';
+            btn.querySelector('img').alt = wpEquran.play;
           });
 
           p.appendChild(btn);

--- a/wp-equran/languages/wp-equran.pot
+++ b/wp-equran/languages/wp-equran.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-01 18:25+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: wp-equran/wp-equran.php:38
+msgid "Play"
+msgstr ""
+
+#: wp-equran/wp-equran.php:39
+msgid "Pause"
+msgstr ""

--- a/wp-equran/wp-equran.php
+++ b/wp-equran/wp-equran.php
@@ -6,7 +6,14 @@ Description: Simple digital Quran plugin with built‑in dataset.
 Author: Kresuber Digital
 Version: 1.0.0
 License: MIT
+Text Domain: wp-equran
+Domain Path: /languages
 */
+
+function wpequran_load_textdomain() {
+    load_plugin_textdomain('wp-equran', false, dirname(plugin_basename(__FILE__)) . '/languages');
+}
+add_action('plugins_loaded', 'wpequran_load_textdomain');
 
 function wpequran_enqueue_assets() {
     $base = plugin_dir_url(__FILE__);
@@ -26,7 +33,11 @@ function wpequran_enqueue_assets() {
     wp_localize_script(
         'wpequran-script',
         'wpEquran',
-        array('pluginUrl' => rtrim($base, '/'))
+        array(
+            'pluginUrl' => rtrim($base, '/'),
+            'play'      => __('Play', 'wp-equran'),
+            'pause'     => __('Pause', 'wp-equran'),
+        )
     );
 }
 add_action('wp_enqueue_scripts', 'wpequran_enqueue_assets');


### PR DESCRIPTION
## Summary
- declare text domain and domain path for WP eQuran
- load plugin translation files and pass translated strings to JS
- localize play/pause button in script.js
- generate POT template for translators

## Testing
- `node --check wp-equran/assets/script.js`
- `xgettext -n --keyword=__ --keyword=_e --add-comments=translators --from-code=UTF-8 -o wp-equran/languages/wp-equran.pot wp-equran/wp-equran.php`

------
https://chatgpt.com/codex/tasks/task_e_686427b7240c8328818d355d0542791c